### PR TITLE
Detect end of block comments in express.d.ts

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -297,7 +297,7 @@ function bundle(options) {
 			var match;
 
 			// block comment end
-			if (/^[ \t]*\*+\//.test(line)) {
+			if (/^[((=====)(=*)) \t]*\*+\//.test(line)) {
 				multiComment.push(line);
 				popBlock();
 				return;


### PR DESCRIPTION
Allows the end of a block comment to contain a line such as `============`
see https://github.com/TypeStrong/dts-bundle/issues/16 for more details