### PR TITLE
Added referenceExternals for cases when you want to render reference tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ var opts = {
 	// include typings outside of the 'baseDir' (i.e. like node.d.ts)
 	// - default: false
 	externals: false,
+	// reference external modules as <reference path="..." /> tags
+	// - default: false
+	referenceExternals: false,
 	// filter to exclude typings, either a RegExp or a callback. match path relative to opts.baseDir
 	// - RegExp: a match excludes the file
 	// - function: (file:String, external:Boolean) return true to exclude, false to allow

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -74,6 +74,7 @@ export function bundle(options: Options) {
     const externals = optValue(options.externals, false);
     const exclude = optValue(options.exclude, null);
     const removeSource = optValue(options.removeSource, false);
+    const referenceExternals = optValue(options.referenceExternals, false);
 
     // regular (non-jsdoc) comments are not actually supported by declaration compiler
     const comments = false;
@@ -253,7 +254,12 @@ export function bundle(options: Options) {
     if (externalDependencies.length > 0) {
         content += '// Dependencies for this module:' + newline;
         externalDependencies.forEach(file => {
-            content += '//   ' + path.relative(baseDir, file).replace(/\\/g, '/') + newline;
+            if (referenceExternals) {
+                content += formatReference(path.relative(baseDir, file).replace(/\\/g, '/')) + newline;
+            }
+            else {
+                content += '//   ' + path.relative(baseDir, file).replace(/\\/g, '/') + newline;
+            }
         });
     }
 


### PR DESCRIPTION
Added referenceExternals for cases when you want to render reference tags.

Sometimes I want to render a reference tag to an external dependency. With this flag this is possible and unobstrusive with the current functionality.