### PR TITLE
Allow not existing files for external modules

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -197,14 +197,14 @@ export function bundle(options: Options) {
 
             parse.externalImports.forEach(name => {
                 let p = exportMap[name];
+                if (!externals) {
+                    trace(' - exclude external %s', name);
+                    pushUnique(externalDependencies, !p ? name : p.file);
+                    return;
+                }                
                 if (isExclude(path.relative(baseDir, p.file), true)) {
                     trace(' - exclude external filter %s', name);
                     pushUnique(excludedTypings, p.file);
-                    return;
-                }
-                if (!externals) {
-                    trace(' - exclude external%s', name);
-                    pushUnique(externalDependencies, p.file);
                     return;
                 }
                 trace(' - include external %s', name);


### PR DESCRIPTION
When process the external imports may be that the file don't exists, then when you access to the property "file" of exportMap item and get an error.

I think the first to do is to check `externals` parameters, if `externals` is false you haven't if the file is excluded, and if 'externals' is false It may be that the file does not exist then you have to check `p` to access to `p.file`.

I'm generating .d.ts for `ng-forward` project and I have been problems with `reactive/rxjs` import, with these changes work fine.