### PR TITLE
Added support for Module Folders output.

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ var opts = {
     // *** Experimental, TEST NEEDED
     // - default: false     
     emitOnNoIncludedFileNotFound: false,    
+    // output d.ts as designed for module folder. (no declare modules)
+    outputAsModuleFolder: false,
     // path to file that contains the header
     // // insert a header in output file. i.e.: http://definitelytyped.org/guides/contributing.html#header
     // - default: null
@@ -178,6 +180,16 @@ export * from './Utils/AngularHelpers';
 ````
 
 Then `dts-bundle` processes this file. When finish the temporally file is deleted.
+
+### Module folders
+NPM introduced support for in-package typings,
+it is done by adding typings key into package.json file, which should refer to the
+typings file.
+when this is the case, the d.ts file is threated as module folder, and declare module
+is not allowed.
+
+* `outputAsModuleFolder`. When using this option output d.ts will be compatible with module folder. which means, no declare module are used,
+and all internal references are removed as they are merged into the output d.ts.
 
 ### Files not found.
 
@@ -249,6 +261,7 @@ Options:
   --verbose                       enable verbose mode, prints detailed info about all references and includes/excludes
   --emitOnIncludedFileNotFound    emit although included files not found. See readme "Files not found" section.
   --emitOnNoIncludedFileNotFound  emit although no included files not found. See readme "Files not found" section.
+  --outputAsModuleFolder          output as module folder format (no declare module) . See readme "Module folders" section.
   --headerPath [value]            path to file that contains the header
 ````
 

--- a/lib/dts-bundle.js
+++ b/lib/dts-bundle.js
@@ -27,6 +27,7 @@ function mapOptions(argObj) {
         "referenceExternals",
         "emitOnIncludedFileNotFound",
         "emitOnNoIncludedFileNotFound",
+        "outputAsModuleFolder",
         "headerPath"
     ];
 
@@ -77,6 +78,7 @@ program
     .option('--verbose', 'enable verbose mode, prints detailed info about all references and includes/excludes')
     .option('--emitOnIncludedFileNotFound', 'emit although included files not found. See readme "Files not found" section. ')
     .option('--emitOnNoIncludedFileNotFound', 'emit although no included files not found. See readme "Files not found" section. ')
+    .option('--outputAsModuleFolder', 'output as module folder format (no declare module) . See readme "Module folders" section.')
     .option('--headerPath [value]', 'path to file that contains the header')
     .parse(process.argv);
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -192,6 +192,7 @@ export function bundle(options: Options): BundleResult {
     trace('excluded typings (will always be excluded from output)');
 
     let fileMap: { [name: string]: Result; } = Object.create(null);
+    let globalExternalImports: string[] = [];
     let mainParse: Result; // will be parsed result of first parsed file
     let externalTypings: string[] = [];
     let inExternalTypings = (file: string) => externalTypings.indexOf(file) !== -1;
@@ -328,6 +329,11 @@ export function bundle(options: Options): BundleResult {
                 content += '//   ' + path.relative(baseDir, file).replace(/\\/g, '/') + newline;
             }
         });
+    }
+
+    if ( globalExternalImports.length > 0 ) {
+        content += newline;
+        content += globalExternalImports.join(newline) + newline;
     }
 
     content += newline;
@@ -707,12 +713,16 @@ export function bundle(options: Options): BundleResult {
                     let modLine: ModLine = {
                         original: line
                     };
-                    res.lines.push(modLine);
                     trace(' - import external %s', moduleName);
 
                     pushUnique(res.externalImports, moduleName);
                     if (externals) {
                         res.importLineRef.push(modLine);
+                    }
+                    if (!outputAsModuleFolder) {
+                        res.lines.push(modLine);
+                    } else {
+                        pushUnique(globalExternalImports, line);
                     }
                 }
             }


### PR DESCRIPTION
NPM introduced support for in-package typings,
it is done by adding typings key into package.json file, which should refer to the
typings file.
when this is the case, the d.ts file is threated as module folder, and declare module
is not allowed.

options `outputAsModuleFolder` was added to add support for module
folder output.