### PR TITLE
headerText option

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,12 @@ var opts = {
     // path to file that contains the header
     // // insert a header in output file. i.e.: http://definitelytyped.org/guides/contributing.html#header
     // - default: null
-    headerPath: "path/to/header/file"     
+    headerPath: "path/to/header/file",
+    // text of the the header
+    // doesn't work with headerPath
+    // // insert a header in output file. i.e.: http://definitelytyped.org/guides/contributing.html#header
+    // - default: ''
+    headerTex: "" 
 };
 
 // require module
@@ -263,6 +268,7 @@ Options:
   --emitOnNoIncludedFileNotFound  emit although no included files not found. See readme "Files not found" section.
   --outputAsModuleFolder          output as module folder format (no declare module) . See readme "Module folders" section.
   --headerPath [value]            path to file that contains the header
+  --headerText [value]            text of the header. Doesn't work with headerPath.
 ````
 
 For example: 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -41,6 +41,7 @@ export interface Options {
     emitOnIncludedFileNotFound?: boolean;
     emitOnNoIncludedFileNotFound?: boolean;
     headerPath: string;
+    headerText: string;
 }
 
 export interface ModLine {
@@ -103,6 +104,7 @@ export function bundle(options: Options): BundleResult {
     const emitOnIncludedFileNotFound = optValue(options.emitOnIncludedFileNotFound, false);
     const emitOnNoIncludedFileNotFound = optValue(options.emitOnNoIncludedFileNotFound, false);
     const _headerPath = optValue(options.headerPath, null);
+    const headerText = optValue(options.headerText, '');
 
     // regular (non-jsdoc) comments are not actually supported by declaration compiler
     const comments = false;
@@ -141,6 +143,7 @@ export function bundle(options: Options): BundleResult {
     trace('emitOnIncludedFileNotFound:   %s', emitOnIncludedFileNotFound ? "yes" : "no");
     trace('emitOnNoIncludedFileNotFound: %s', emitOnNoIncludedFileNotFound ? "yes" : "no");
     trace("headerPath    %s", headerPath);
+    trace("headerText    %s", headerText);
 
     if (!allFiles) {
         assert(fs.existsSync(mainFile), 'main does not exist: ' + mainFile);
@@ -153,6 +156,8 @@ export function bundle(options: Options): BundleResult {
             assert(fs.existsSync(headerPath), 'header does not exist: ' + headerPath);
             headerData = fs.readFileSync(headerPath, 'utf8') + headerData;
         }
+    } else if (headerText) {
+        headerData = '/*' + headerText + '*/\n';
     }
 
     let isExclude: (file: string, arg?: boolean) => boolean;


### PR DESCRIPTION
Hello! Thanks for your work! I've tried to use headerPath and separate file, but if I require/import something on it I get "require/import" in my header.

So I added the possibility to set the text for the header instead of path. Example of using:
`
headerText: ["Type definitions for Survey JavaScript library v" + libraryVersion,
                    "Project: http://surveyjs.org/",
                    "Definitions by: Andrew Telnov <https://github.com/andrewtelnov/>"].join("\n")
`
_where **libraryVersion** is variable **version** from my package.json_.

Could you check it please?