### PR TITLE
ignore files inside node_modules when removing declarations files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /test/tmp
 /test/build
 !/test/src/typings/*.d.ts
+!/test/src/node_modules/*.d.ts
 /test/src/**/*.d.ts
 /test/src/**/*.js
 /test/src/**/*.js.map

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -22,6 +22,7 @@ const identifierExp = /^\w+(?:[\.-]\w+)*$/;
 const fileExp = /^([\./].*|.:.*)$/;
 const privateExp = /^[ \t]*(?:static )?private (?:static )?/;
 const publicExp = /^([ \t]*)(static |)(public |)(static |)(.*)/;
+const nodeModulesExp = /\/node_modules\//;
 
 export interface Options {
     main: string;
@@ -374,11 +375,11 @@ export function bundle(options: Options): BundleResult {
     if (removeSource) {
         trace('\n### remove source typings ###');
 
-        sourceTypings.forEach(p => {
+        sourceTypings.forEach((filePath: string) => {
             // safety check, only delete .d.ts files, leave our outFile intact for now
-            if (p !== outFile && dtsExp.test(p) && fs.statSync(p).isFile()) {
-                trace(' - %s', p);
-                fs.unlinkSync(p);
+            if (filePath !== outFile && dtsExp.test(filePath) && !nodeModulesExp.test(filePath) && fs.statSync(filePath).isFile()) {
+                trace(' - %s', filePath);
+                fs.unlinkSync(filePath);
             }
         });
     }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@types/detect-indent": "0.1.30",
     "@types/glob": "5.0.30",
     "@types/mkdirp": "0.3.29",
-    "@types/node": "8.0.0",
+    "@types/node": "8.0.14",
     "commander": "^2.9.0",
     "detect-indent": "^0.2.0",
     "glob": "^6.0.4",

--- a/test/expected/default/foo-mx.d.ts
+++ b/test/expected/default/foo-mx.d.ts
@@ -1,13 +1,16 @@
 // Dependencies for this module:
 //   ../../src/typings/external.d.ts
+//   ../../src/node_modules/modules.d.ts
 
 declare module 'foo-mx' {
     import exp = require('foo-mx/lib/exported-sub');
     import mod1 = require('external1');
+    import nodeModule = require('node_module');
     export import Foo = require('foo-mx/Foo');
     export function run(foo?: Foo): Foo;
     export function flep(): exp.ExternalContainer;
     export function bar(): mod1.SomeType;
+    export function baz(): nodeModule.SomeType;
 }
 
 declare module 'foo-mx/lib/exported-sub' {

--- a/test/expected/excludeExp/foo-mx.d.ts
+++ b/test/expected/excludeExp/foo-mx.d.ts
@@ -1,13 +1,16 @@
 // Dependencies for this module:
 //   ../../src/typings/external.d.ts
+//   ../../src/node_modules/modules.d.ts
 
 declare module 'foo-mx' {
     import exp = require('foo-mx/lib/exported-sub');
     import mod1 = require('external1');
+    import nodeModule = require('node_module');
     export import Foo = require('foo-mx/Foo');
     export function run(foo?: Foo): Foo;
     export function flep(): exp.ExternalContainer;
     export function bar(): mod1.SomeType;
+    export function baz(): nodeModule.SomeType;
 }
 
 declare module 'foo-mx/Foo' {

--- a/test/expected/excludeFunc/foo-mx.d.ts
+++ b/test/expected/excludeFunc/foo-mx.d.ts
@@ -1,13 +1,16 @@
 // Dependencies for this module:
 //   ../../src/typings/external.d.ts
+//   ../../src/node_modules/modules.d.ts
 
 declare module 'foo-mx' {
     import exp = require('foo-mx/lib/exported-sub');
     import mod1 = require('external1');
+    import nodeModule = require('node_module');
     export import Foo = require('foo-mx/Foo');
     export function run(foo?: Foo): Foo;
     export function flep(): exp.ExternalContainer;
     export function bar(): mod1.SomeType;
+    export function baz(): nodeModule.SomeType;
 }
 
 declare module 'foo-mx/Foo' {

--- a/test/expected/externals/foo-mx.d.ts
+++ b/test/expected/externals/foo-mx.d.ts
@@ -2,10 +2,12 @@
 declare module 'foo-mx' {
     import exp = require('foo-mx/lib/exported-sub');
     import mod1 = require('foo-mx/index//external1');
+    import nodeModule = require('foo-mx/index//node_module');
     export import Foo = require('foo-mx/Foo');
     export function run(foo?: Foo): Foo;
     export function flep(): exp.ExternalContainer;
     export function bar(): mod1.SomeType;
+    export function baz(): nodeModule.SomeType;
 }
 
 declare module 'foo-mx/index//external1' {
@@ -16,6 +18,12 @@ declare module 'foo-mx/index//external1' {
 
 declare module 'foo-mx/index//external2' {
     export class AnotherType {
+        foo(): void;
+    }
+}
+
+declare module 'foo-mx/index//node_module' {
+    export class SomeType {
         foo(): void;
     }
 }

--- a/test/expected/includeExclude/foo-mx.d.ts
+++ b/test/expected/includeExclude/foo-mx.d.ts
@@ -2,10 +2,12 @@
 declare module 'foo-mx' {
     import exp = require('foo-mx/lib/exported-sub');
     import mod1 = require('foo-mx/index//external1');
+    import nodeModule = require('foo-mx/index//node_module');
     export import Foo = require('foo-mx/Foo');
     export function run(foo?: Foo): Foo;
     export function flep(): exp.ExternalContainer;
     export function bar(): mod1.SomeType;
+    export function baz(): nodeModule.SomeType;
 }
 
 declare module 'foo-mx/index//external1' {
@@ -16,6 +18,12 @@ declare module 'foo-mx/index//external1' {
 
 declare module 'foo-mx/index//external2' {
     export class AnotherType {
+        foo(): void;
+    }
+}
+
+declare module 'foo-mx/index//node_module' {
+    export class SomeType {
         foo(): void;
     }
 }

--- a/test/expected/out/fizz/buzz.d.ts
+++ b/test/expected/out/fizz/buzz.d.ts
@@ -1,13 +1,16 @@
 // Dependencies for this module:
 //   ../../src/typings/external.d.ts
+//   ../../src/node_modules/modules.d.ts
 
 declare module 'foo-mx' {
     import exp = require('foo-mx/lib/exported-sub');
     import mod1 = require('external1');
+    import nodeModule = require('node_module');
     export import Foo = require('foo-mx/Foo');
     export function run(foo?: Foo): Foo;
     export function flep(): exp.ExternalContainer;
     export function bar(): mod1.SomeType;
+    export function baz(): nodeModule.SomeType;
 }
 
 declare module 'foo-mx/lib/exported-sub' {

--- a/test/expected/remove/foo-mx.d.ts
+++ b/test/expected/remove/foo-mx.d.ts
@@ -1,13 +1,16 @@
 // Dependencies for this module:
 //   ../../src/typings/external.d.ts
+//   ../../src/node_modules/modules.d.ts
 
 declare module 'foo-mx' {
     import exp = require('foo-mx/lib/exported-sub');
     import mod1 = require('external1');
+    import nodeModule = require('node_module');
     export import Foo = require('foo-mx/Foo');
     export function run(foo?: Foo): Foo;
     export function flep(): exp.ExternalContainer;
     export function bar(): mod1.SomeType;
+    export function baz(): nodeModule.SomeType;
 }
 
 declare module 'foo-mx/lib/exported-sub' {

--- a/test/expected/seprinnew/bar-mx.d.ts
+++ b/test/expected/seprinnew/bar-mx.d.ts
@@ -1,13 +1,16 @@
 // Dependencies for this module: //$
 //   ../../src/typings/external.d.ts //$
+//   ../../src/node_modules/modules.d.ts //$
  //$
 declare module 'bar-mx' { //$
 	import exp = require('--bar-mx#lib#exported-sub'); //$
 	import mod1 = require('external1'); //$
+	import nodeModule = require('node_module'); //$
 	export import Foo = require('--bar-mx#Foo'); //$
 	export function run(foo?: Foo): Foo; //$
 	export function flep(): exp.ExternalContainer; //$
 	export function bar(): mod1.SomeType; //$
+	export function baz(): nodeModule.SomeType; //$
 } //$
  //$
 declare module '--bar-mx#lib#exported-sub' { //$

--- a/test/src/main/index.ts
+++ b/test/src/main/index.ts
@@ -1,8 +1,10 @@
 /// <reference path="./../typings/external.d.ts" />
+/// <reference path="./../node_modules/modules.d.ts" />
 
 import int = require('./lib/only-internal');
 import exp = require('./lib/exported-sub');
 import mod1 = require('external1');
+import nodeModule = require('node_module');
 
 export import Foo = require('./Foo');
 /*
@@ -22,4 +24,9 @@ export function flep(): exp.ExternalContainer {
 // bar that
 export function bar(): mod1.SomeType {
     return new mod1.SomeType();
+}
+
+// baz some of that
+export function baz(): nodeModule.SomeType {
+    return new nodeModule.SomeType();
 }

--- a/test/src/node_modules/modules.d.ts
+++ b/test/src/node_modules/modules.d.ts
@@ -1,0 +1,5 @@
+declare module 'node_module' {
+    export class SomeType {
+        foo(): void;
+    }
+}


### PR DESCRIPTION
fixes #53 

Exclude node_modules files when cleaning up declarations with the removeSource flag enabled