### PR TITLE
Allow multiple ambient declarations for same module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 /test/build
 !/test/src/typings/*.d.ts
 /test/src/**/*.d.ts
+!/test/src/ambient/*.d.ts
 /test/src/**/*.js
 /test/src/**/*.js.map
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -67,6 +67,10 @@ module.exports = function (grunt) {
 			testConflicts: {
 				src: ['test/src/conflicts/dirname/index.ts'],
 				outDir: 'test/build/conflicts/dirname'
+			},
+			testAmbient: {
+				src: ['test/src/ambient/index.ts'],
+				outDir: 'test/build/ambient'
 			}
 		},
 		mochaTest: {
@@ -92,6 +96,7 @@ module.exports = function (grunt) {
 		'ts:testEs6',
 		'ts:testCommonJs',
 		'ts:testConflicts',
+		'ts:testAmbient',
 		'run'
 	]);
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -267,20 +267,29 @@ export function bundle(options: Options): BundleResult {
             parse.externalImports.forEach(name => {
                 let parses = exportMap[name];
 
-                for (let p of parses) {
-                    if (!externals) {
-                        trace(' - exclude external %s', name);
-                        pushUnique(externalDependencies, !p ? name : p.file);
-                        return;
+                if (!externals) {
+                    trace(' - exclude external %s', name);
+
+                    if (parses) {
+                        for (let p of parses) {
+                            pushUnique(externalDependencies, p.file);
+                        }
+                    } else {
+                        pushUnique(externalDependencies, name);
                     }
-                    if (isExclude(path.relative(baseDir, p.file), true)) {
-                        trace(' - exclude external filter %s', name);
-                        pushUnique(excludedTypings, p.file);
-                        return;
+                } else {
+                    if (parses) {
+                        for (let p of parses) {
+                            if (isExclude(path.relative(baseDir, p.file), true)) {
+                                trace(' - exclude external filter %s', name);
+                                pushUnique(excludedTypings, p.file);
+                            } else {
+                                trace(' - include external %s', name);
+                                assert(p, name);
+                                queue.push(p);
+                            }
+                        }
                     }
-                    trace(' - include external %s', name);
-                    assert(p, name);
-                    queue.push(p);
                 }
             });
             parse.relativeImports.forEach(file => {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -183,7 +183,7 @@ export function bundle(options: Options): BundleResult {
             mainFileContent += generatedLine + "\n";
         });
         mainFile = path.resolve(baseDir, "dts-bundle.tmp." + exportName + ".d.ts");
-        fs.writeFileSync(mainFile, mainFileContent, 'utf8');
+        fs.writeFileSync(mainFile, mainFileContent, { encoding: 'utf8' });
     }
 
     trace('\n### find typings ###');
@@ -424,7 +424,7 @@ export function bundle(options: Options): BundleResult {
             }
         }
 
-        fs.writeFileSync(outFile, content, 'utf8');
+        fs.writeFileSync(outFile, content, { encoding: 'utf8' });
         bundleResult.emitted = true;
     } else {
         warning(" XXX Not emit due to exist files not found.")
@@ -587,7 +587,7 @@ export function bundle(options: Options): BundleResult {
         if (fs.lstatSync(file).isDirectory()) { // if file is a directory then lets assume commonjs convention of an index file in the given folder
             file = path.join(file, 'index.d.ts');
         }
-        const code = fs.readFileSync(file, 'utf8').replace(bomOptExp, '').replace(/\s*$/, '');
+        const code = fs.readFileSync(file, { encoding: 'utf8' }).replace(bomOptExp, '').replace(/\s*$/, '');
         res.indent = detectIndent(code) || indent;
 
         // buffer multi-line comments, handle JSDoc

--- a/test/expected/ambient/foo-mx.d.ts
+++ b/test/expected/ambient/foo-mx.d.ts
@@ -1,5 +1,7 @@
 // Dependencies for this module:
 //   ambient1.d.ts
+//   ambient2.d.ts
+//   ../../src/ambient/mymodule.d.ts
 
 declare module 'foo-mx' {
     export { MyInterface } from 'mymodule';

--- a/test/expected/ambient/foo-mx.d.ts
+++ b/test/expected/ambient/foo-mx.d.ts
@@ -1,0 +1,29 @@
+// Dependencies for this module:
+//   ambient1.d.ts
+
+declare module 'foo-mx' {
+    export { MyInterface } from 'mymodule';
+    export { Sup1 } from 'foo-mx/ambient1';
+    export { Sup2 } from 'foo-mx/ambient2';
+}
+
+declare module 'foo-mx/ambient1' {
+    module 'mymodule' {
+        interface MyInterface {
+            prop1: string;
+        }
+    }
+    export interface Sup1 {
+    }
+}
+
+declare module 'foo-mx/ambient2' {
+    module 'mymodule' {
+        interface MyInterface {
+            prop2: string;
+        }
+    }
+    export interface Sup2 {
+    }
+}
+

--- a/test/src/ambient/ambient1.ts
+++ b/test/src/ambient/ambient1.ts
@@ -1,0 +1,10 @@
+
+/// <reference path="./mymodule.d.ts" />
+
+declare module 'mymodule' {
+    interface MyInterface {
+        prop1: string
+    }
+}
+
+export interface Sup1 {}

--- a/test/src/ambient/ambient2.ts
+++ b/test/src/ambient/ambient2.ts
@@ -1,0 +1,10 @@
+
+/// <reference path="./mymodule.d.ts" />
+
+declare module 'mymodule' {
+    interface MyInterface {
+        prop2: string
+    }
+}
+
+export interface Sup2 {}

--- a/test/src/ambient/index.ts
+++ b/test/src/ambient/index.ts
@@ -1,0 +1,3 @@
+export { MyInterface } from 'mymodule';
+export { Sup1 } from './ambient1';
+export { Sup2 } from './ambient2';

--- a/test/src/ambient/mymodule.d.ts
+++ b/test/src/ambient/mymodule.d.ts
@@ -1,0 +1,6 @@
+
+declare module 'mymodule' {
+    export interface MyInterface {
+        prop0: string
+    }
+}

--- a/test/test.js
+++ b/test/test.js
@@ -385,6 +385,56 @@ describe('dts bundle', function () {
 	});
 
 	(function testit(name, assertion, run) {
+		var buildDir = path.resolve(__dirname, 'build', 'ambient');
+		var call = function (done) {
+			var testDir = path.join(tmpDir, name);
+			var expDir = path.join(expectDir, name);
+
+			mkdirp.sync(testDir);
+
+			ncp.ncp(buildDir, testDir, function (err) {
+				if (err) {
+					done(err);
+					return;
+				}
+				assertion(testDir, expDir);
+				done();
+			});
+		};
+
+		var label = 'bundle ' + name;
+
+		if (run === 'skip') {
+			it.skip(label, call);
+		}
+		else if (run === 'only') {
+			it.only(label, call);
+		}
+		else {
+			it(label, call);
+		}
+	})('ambient', function (actDir, expDir) {
+		var result = dts.bundle({
+			name: 'foo-mx',
+			main: path.join(actDir, 'index.d.ts'),
+			newline: '\n',
+            verbose: true,
+            headerPath: "none"
+		});
+		var name = 'foo-mx.d.ts';
+		var actualFile = path.join(actDir, name);
+        assert.isTrue(result.emitted, "not emit " + actualFile);
+		var expectedFile = path.join(expDir, name);
+		assertFiles(actDir, [
+			name,
+			'index.d.ts',
+			'ambient1.d.ts',
+			'ambient2.d.ts',
+		]);
+		assert.strictEqual(getFile(actualFile), getFile(expectedFile));
+	});
+
+	(function testit(name, assertion, run) {
 		var buildDir = path.resolve(__dirname, 'build', 'es6');
 		var call = function (done) {
 			var testDir = path.join(tmpDir, name);


### PR DESCRIPTION
Writing [ambient modules](https://www.typescriptlang.org/docs/handbook/modules.html#ambient-modules) introduces the possibility of having multiple module declarations of the same name. dts-bundle chokes on this and says "already got export for...". I've modified the code to keep track of an *array* of module definitions in order to accommodate this use case. Fixes #72

It's unclear to me if the "already got export for" error is *ever* desirable for non-ambient modules, but my gut tells me no.

CC @eddow