### PR TITLE
Correctly process ES6 inline/side-effect imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 /test/build
 !/test/src/typings/*.d.ts
 /test/src/**/*.d.ts
+!/test/src/inline_imports/*.d.ts
 /test/src/**/*.js
 /test/src/**/*.js.map
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -767,7 +767,7 @@ export function bundle(options: Options): BundleResult {
                 trace(' - declare %s', moduleName);
                 pushUnique(res.exports, moduleName);
                 let modLine: ModLine = {
-                    original: line
+                    original: inSourceTypings(file) ? removeDeclares(line) : line
                 };
                 res.relativeRef.push(modLine); // TODO
                 res.lines.push(modLine);
@@ -779,14 +779,10 @@ export function bundle(options: Options): BundleResult {
                     let [_, sp, static1, pub, static2, ident] = match;
                     line = sp + static1 + static2 + ident;
                 }
-                if (inSourceTypings(file)) {
-                    res.lines.push({
-                        original: removeDeclares(line)
-                    });
-                }
-                else {
-                    res.lines.push({ original: line });
-                }
+
+                res.lines.push({
+                    original: inSourceTypings(file) ? removeDeclares(line) : line
+                });
             }
         });
 
@@ -846,7 +842,7 @@ function replaceImportExportEs6(line: string, replacer: (str: string) => string)
 function removeDeclares(line: string) {
     return line
         .replace(/^(export )?declare /g, '$1')
-        .replace(/^declare (const|let)/g, '$1')
+        .replace(/^\s*declare (const|let|module)/g, '$1')
 }
 
 function replaceExternal(line: string, replacer: (str: string) => string) {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -183,7 +183,7 @@ export function bundle(options: Options): BundleResult {
             mainFileContent += generatedLine + "\n";
         });
         mainFile = path.resolve(baseDir, "dts-bundle.tmp." + exportName + ".d.ts");
-        fs.writeFileSync(mainFile, mainFileContent, 'utf8');
+        fs.writeFileSync(mainFile, mainFileContent, { encoding: 'utf8' });
     }
 
     trace('\n### find typings ###');
@@ -424,7 +424,7 @@ export function bundle(options: Options): BundleResult {
             }
         }
 
-        fs.writeFileSync(outFile, content, 'utf8');
+        fs.writeFileSync(outFile, content, { encoding: 'utf8' });
         bundleResult.emitted = true;
     } else {
         warning(" XXX Not emit due to exist files not found.")
@@ -587,7 +587,7 @@ export function bundle(options: Options): BundleResult {
         if (fs.lstatSync(file).isDirectory()) { // if file is a directory then lets assume commonjs convention of an index file in the given folder
             file = path.join(file, 'index.d.ts');
         }
-        const code = fs.readFileSync(file, 'utf8').replace(bomOptExp, '').replace(/\s*$/, '');
+        const code = fs.readFileSync(file, { encoding: 'utf8' }).replace(bomOptExp, '').replace(/\s*$/, '');
         res.indent = detectIndent(code) || indent;
 
         // buffer multi-line comments, handle JSDoc

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "dts-bundle",
-  "version": "0.7.3",
+  "name": "@arshaw/dts-bundle",
+  "version": "0.7.3-fork",
   "description": "Export TypeScript .d.ts files as an external module definition",
   "keywords": [
     "typescript",

--- a/test/expected/es6/foo-mx.d.ts
+++ b/test/expected/es6/foo-mx.d.ts
@@ -5,6 +5,7 @@ declare module 'foo-mx' {
     import { A } from "foo-mx/lib/subC";
     import { bar } from "foo-mx/lib/subD";
     import { foo as buzz } from "foo-mx/lib/subE";
+    import "foo-mx/lib/subF";
     export function indexA(): subB.A;
     export function indexB(): subB.B;
     export function indexC(): A;
@@ -49,6 +50,18 @@ declare module 'foo-mx/lib/subD' {
 }
 
 declare module 'foo-mx/lib/subE' {
+    export interface A {
+        name: string;
+    }
+    export class B {
+        name: string;
+    }
+    export default function test(): A;
+    export function foo(): A;
+    export function bar(): A;
+}
+
+declare module 'foo-mx/lib/subF' {
     export interface A {
         name: string;
     }

--- a/test/expected/inline_imports/foo-mx.d.ts
+++ b/test/expected/inline_imports/foo-mx.d.ts
@@ -1,0 +1,13 @@
+
+declare module 'foo-mx' {
+    const _default: import('foo-mx/lib').Plugin;
+    export default _default;
+}
+
+declare module 'foo-mx/lib' {
+    export interface Plugin {
+        name: string
+        action: any
+    }
+}
+

--- a/test/src/es6/index.ts
+++ b/test/src/es6/index.ts
@@ -4,6 +4,7 @@ import * as subB from "./sub";
 import subC, {A} from "./lib/subC";
 import {bar} from "./lib/subD";
 import {foo as buzz} from "./lib/subE";
+import "./lib/subF";
 
 export function indexA() {
 	return subA();

--- a/test/src/es6/lib/subF.ts
+++ b/test/src/es6/lib/subF.ts
@@ -1,0 +1,11 @@
+export interface A {
+	name: string;
+}
+
+export class B {
+	name: string;
+}
+
+export default function test(): A { return null; }
+export function foo(): A { return null; }
+export function bar(): A { return null; }

--- a/test/src/inline_imports/index.d.ts
+++ b/test/src/inline_imports/index.d.ts
@@ -1,0 +1,2 @@
+declare const _default: import('./lib').Plugin;
+export default _default;

--- a/test/src/inline_imports/lib.d.ts
+++ b/test/src/inline_imports/lib.d.ts
@@ -1,0 +1,4 @@
+export interface Plugin {
+    name: string
+    action: any
+}

--- a/test/test.js
+++ b/test/test.js
@@ -475,6 +475,7 @@ describe('dts bundle', function () {
 			'lib/subC.d.ts',
 			'lib/subD.d.ts',
 			'lib/subE.d.ts',
+			'lib/subF.d.ts',
 			'sub.d.ts'
 		]);
 		assert.strictEqual(getFile(actualFile), getFile(expectedFile));
@@ -522,6 +523,7 @@ describe('dts bundle', function () {
 			'lib/subC.d.ts',
 			'lib/subD.d.ts',
 			'lib/subE.d.ts',
+			'lib/subF.d.ts',
 			'sub.d.ts'
 		]);
 		assert.strictEqual(getFile(actualFile), getFile(expectedFile));

--- a/test/test.js
+++ b/test/test.js
@@ -385,6 +385,50 @@ describe('dts bundle', function () {
 	});
 
 	(function testit(name, assertion, run) {
+		var buildDir = path.resolve(__dirname, 'src', 'inline_imports');
+		var call = function (done) {
+			var testDir = path.join(tmpDir, name);
+			var expDir = path.join(expectDir, name);
+
+			mkdirp.sync(testDir);
+
+			ncp.ncp(buildDir, testDir, function (err) {
+				if (err) {
+					done(err);
+					return;
+				}
+				assertion(testDir, expDir);
+				done();
+			});
+		};
+
+		var label = 'bundle ' + name;
+
+		if (run === 'skip') {
+			it.skip(label, call);
+		}
+		else if (run === 'only') {
+			it.only(label, call);
+		}
+		else {
+			it(label, call);
+		}
+	})('inline_imports', function (actDir, expDir) {
+		var result = dts.bundle({
+			name: 'foo-mx',
+			main: path.join(actDir, 'index.d.ts'),
+			newline: '\n',
+            verbose: true,
+            headerPath: "none"
+		});
+		var name = 'foo-mx.d.ts';
+		var actualFile = path.join(actDir, name);
+        assert.isTrue(result.emitted, "not emit " + actualFile);
+		var expectedFile = path.join(expDir, name);
+		assert.strictEqual(getFile(actualFile), getFile(expectedFile));
+	});
+
+	(function testit(name, assertion, run) {
 		var buildDir = path.resolve(__dirname, 'build', 'es6');
 		var call = function (done) {
 			var testDir = path.join(tmpDir, name);


### PR DESCRIPTION
My typescript project sometimes outputs lines like these in the generated .d.ts files:

```js
declare const _default: import("../plugin-system").PluginDef;
export default _default;
```

It's essentially an inline ES6 import statement and it's valid code within a typescript definition file. I was having trouble pinpointing the exact conditions necessary to make this happen, but it happens nonetheless.

dts-bundle does not know how to process these and it outputs the line as-is, causing an unresolved module error. This PR fixes it.

**Edit**

The following type of imports were also not working ("side-effect-only" imports):

```js
import "./myfile";
```

I've included a fix for that as well.