### PR TITLE
Hook for modifying module body code

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -42,6 +42,7 @@ export interface Options {
     emitOnNoIncludedFileNotFound?: boolean;
     headerPath: string;
     headerText: string;
+    transformModuleBody: (moduleBody: string, moduleName?: string) => string
 }
 
 export interface ModLine {
@@ -544,16 +545,27 @@ export function bundle(options: Options): BundleResult {
         return (lines.length === 0 ? '' : i + lines.join(newline + i)) + newline;
     }
 
-    function formatModule(file: string, lines: string[]) {
-        let out = '';
-        if (outputAsModuleFolder) {
-            return mergeModulesLines(lines);
+    function transformModuleBody(moduleBody: string, moduleName?: string) {
+        if (typeof options.transformModuleBody === 'function') {
+            moduleBody = options.transformModuleBody(moduleBody, moduleName);
         }
+        return moduleBody
+    }
 
-        out += 'declare module \'' + getExpName(file) + '\' {' + newline;
-        out += mergeModulesLines(lines);
-        out += '}' + newline;
-        return out;
+    function formatModule(file: string, lines: string[]) {
+        let moduleBody = mergeModulesLines(lines);
+
+        if (outputAsModuleFolder) {
+            moduleBody = transformModuleBody(moduleBody);
+            return moduleBody;
+
+        } else {
+            let moduleName = getExpName(file);
+            moduleBody = transformModuleBody(moduleBody, moduleName);
+
+            return 'declare module \'' + moduleName + '\' {' + newline +
+                moduleBody + '}' + newline;
+        }
     }
 
     // main info extractor

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -183,7 +183,7 @@ export function bundle(options: Options): BundleResult {
             mainFileContent += generatedLine + "\n";
         });
         mainFile = path.resolve(baseDir, "dts-bundle.tmp." + exportName + ".d.ts");
-        fs.writeFileSync(mainFile, mainFileContent, 'utf8');
+        fs.writeFileSync(mainFile, mainFileContent, { encoding: 'utf8' });
     }
 
     trace('\n### find typings ###');
@@ -424,7 +424,7 @@ export function bundle(options: Options): BundleResult {
             }
         }
 
-        fs.writeFileSync(outFile, content, 'utf8');
+        fs.writeFileSync(outFile, content, { encoding: 'utf8' });
         bundleResult.emitted = true;
     } else {
         warning(" XXX Not emit due to exist files not found.")
@@ -587,7 +587,7 @@ export function bundle(options: Options): BundleResult {
         if (fs.lstatSync(file).isDirectory()) { // if file is a directory then lets assume commonjs convention of an index file in the given folder
             file = path.join(file, 'index.d.ts');
         }
-        const code = fs.readFileSync(file, 'utf8').replace(bomOptExp, '').replace(/\s*$/, '');
+        const code = fs.readFileSync(file, { encoding: 'utf8' }).replace(bomOptExp, '').replace(/\s*$/, '');
         res.indent = detectIndent(code) || indent;
 
         // buffer multi-line comments, handle JSDoc

--- a/test/expected/transformModuleBody/foo-mx.d.ts
+++ b/test/expected/transformModuleBody/foo-mx.d.ts
@@ -1,0 +1,38 @@
+// Dependencies for this module:
+//   ../../src/typings/external.d.ts
+
+declare module 'foo-mx' {
+    import exp = require('foo-mx/lib/exported-sub');
+    import mod1 = require('external1');
+    export import Foo = require('foo-mx/Foo');
+    export function run(foo?: Foo): Foo;
+    export function flep(): exp.ExternalContainer;
+    export function bar(): mod1.SomeType;
+/* INJECTED VIA transformModuleBody */
+}
+
+declare module 'foo-mx/lib/exported-sub' {
+    import Foo = require('foo-mx/Foo');
+    import mod2 = require('external2');
+    export class ExternalContainer {
+        something: mod2.AnotherType;
+    }
+    export function bar(foo: Foo): string;
+    export function bazz(value: string, option?: boolean): string;
+/* INJECTED VIA transformModuleBody */
+}
+
+declare module 'foo-mx/Foo' {
+    class Foo {
+            foo: string;
+            constructor(secret?: string);
+            /**
+                * Bars the foo.
+                */
+            barFoo(): void;
+            /** Foos the baz. */
+            fooBaz(): void;
+    }
+    export = Foo;
+/* INJECTED VIA transformModuleBody */
+}

--- a/test/test.js
+++ b/test/test.js
@@ -332,6 +332,31 @@ describe('dts bundle', function () {
 		assert.strictEqual(getFile(actualFile), getFile(expectedFile));
 	});
 
+	testit('transformModuleBody', function (actDir, expDir) {
+		var result = dts.bundle({
+			name: 'foo-mx',
+			main: path.join(actDir, 'index.d.ts'),
+			newline: '\n',
+            verbose: true,
+			headerPath: "none",
+			transformModuleBody(moduleBody) {
+				return moduleBody + '/* INJECTED VIA transformModuleBody */\n';
+			}
+		});
+		var name = 'foo-mx.d.ts';
+		var actualFile = path.join(actDir, name);
+        assert.isTrue(result.emitted, "not emit " + actualFile);
+		var expectedFile = path.join(expDir, name);
+		assertFiles(actDir, [
+			name,
+			'index.d.ts',
+			'Foo.d.ts',
+			'lib/exported-sub.d.ts',
+			'lib/only-internal.d.ts'
+		]);
+		assert.strictEqual(getFile(actualFile), getFile(expectedFile));
+	});
+
   	//testit('includeExclude_cli', function (actDir, expDir) {  }); // No exclude options available from CLI.
 
 	(function testit(name, assertion, run) {


### PR DESCRIPTION
I had a need to modify each module's code before writing it to disk. String manipulation is weird on .d.ts code, I know, but I needed a workaround for https://github.com/Microsoft/TypeScript/issues/14080

Instead of baking in a solution for 14080 into the code for dts-bundle, I made a callback that allows arbitrary manipulation of generated module-body code. It's an option called `transformModuleBody`.