### PR TITLE
Optionally disable exclusion of private members

### DIFF
--- a/lib/dts-bundle.js
+++ b/lib/dts-bundle.js
@@ -19,10 +19,10 @@ function mapOptions(argObj) {
     //"newline", // Manual
     //"indent", // not implemented
         "prefix",
-//        "separator", not implemented
+    //"separator", not implemented
         "externals",
     //"exclude", // not implemented
-		"includePrivate",
+        "includePrivate",
         "removeSource",
         "verbose",
         "referenceExternals",

--- a/lib/dts-bundle.js
+++ b/lib/dts-bundle.js
@@ -22,6 +22,7 @@ function mapOptions(argObj) {
 //        "separator", not implemented
         "externals",
     //"exclude", // not implemented
+		"includePrivate",
         "removeSource",
         "verbose",
         "referenceExternals",
@@ -71,6 +72,7 @@ program
     .option('--referenceExternals', 'reference external modules as <reference path="..." /> tags *** Experimental, TEST NEEDED')
 //.option('--exclude ', 'filter to exclude typings, either a RegExp or a callback. match path relative to opts.baseDir')
     .option('--removeSource', 'delete all source typings (i.e. "<baseDir>/**/*.d.ts")')
+    .option('--includePrivate', 'include private members in output')
     .option('--newline [style]', 'newline style to use in output file => unix|windows|currentOsDefault', /^(unix|windows|currentOsDefault)$/i)
 //.option('--indent', 'indentation to use in output file')
     .option('--prefix [value]', 'prefix for rewriting module names')

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -35,6 +35,7 @@ export interface Options {
     separator?: string;
     externals?: boolean;
     exclude?: { (file: string): boolean; } | RegExp;
+    includePrivate?: boolean;
     removeSource?: boolean;
     verbose?: boolean;
     referenceExternals?: boolean;
@@ -99,6 +100,7 @@ export function bundle(options: Options): BundleResult {
 
     const externals = optValue(options.externals, false);
     const exclude = optValue(options.exclude, null);
+    const includePrivate = optValue(options.includePrivate, null);
     const removeSource = optValue(options.removeSource, false);
     const referenceExternals = optValue(options.referenceExternals, false);
     const emitOnIncludedFileNotFound = optValue(options.emitOnIncludedFileNotFound, false);
@@ -688,7 +690,7 @@ export function bundle(options: Options): BundleResult {
             }
 
             // private member
-            if (privateExp.test(line)) {
+            if (!includePrivate && privateExp.test(line)) {
                 queuedJSDoc = null;
                 return;
             }


### PR DESCRIPTION
When extending a class that has private members in a mono repo environment vscode will give typescript errors saying the instance of such an object doesn't match the typescript declaration. To fix we need to make sure to include private members in the declaration. This is done by default in typescript but dts-bundle was excluding them without option to include them.